### PR TITLE
Fix translation for "e-mail notification channel"

### DIFF
--- a/src/main/resources/org/sonar/l10n/core_de.properties
+++ b/src/main/resources/org/sonar/l10n/core_de.properties
@@ -739,7 +739,7 @@ server_id_configuration.generation_error=Die Organisation/Firma oder/und IP-Adre
 #
 #------------------------------------------------------------------------------
 
-notification.channel.EmailNotificationChannel=E-Mailnotification.dispatcher.ChangesInReviewAssignedToMeOrCreatedByMe=Veränderungen in Überprüfungen, welche mir zugewiesen sind oder von mir erstellt wurden
+notification.channel.EmailNotificationChannel=Kanal
 
 #------------------------------------------------------------------------------
 #


### PR DESCRIPTION
This PR fixes a bug in the translation, which makes the user's notification settings
- ugly and
- wrong: the text reads "changes ... assigned to me or created by me", but in fact, it's about _all_ notifications.

![2015-08-28_18h08_57](https://cloud.githubusercontent.com/assets/6599417/9551215/ff0f152a-4daf-11e5-9bc1-f093929ca57b.png)
